### PR TITLE
parsermacros-upgrade to 2.11.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,11 +8,11 @@ lazy val bintraySettings: Seq[Setting[_]] = Seq(
 )
 
 lazy val sharedSettings: Seq[Setting[_]] = Seq(
-  version := "0.1.0-SNAPSHOT",
-  scalaVersion := "2.11.6",
+  version := "0.1.1",
+  scalaVersion := "2.11.8",
   organization := "org.duhemm",
   resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
-  libraryDependencies += "org.scalameta" %% "scalameta" % "0.1.0-SNAPSHOT",
+  libraryDependencies += "org.scalameta" % "scalameta_2.11" % "1.6.0",
   libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect" % _),
   scalaHome := sys.props get scalaHomeProperty map file
 ) ++ bintraySettings
@@ -22,7 +22,7 @@ lazy val testSettings: Seq[Setting[_]] = Seq(
   libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.12.2" % "test",
   // We depend on Macro Paradise, because we need its JAR on the classpath to give it to
   // the test compiler.
-  libraryDependencies += "org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full,
+  libraryDependencies += "org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full,
   fullClasspath in Test := {
     val testcp = (fullClasspath in Test).value.files.map(_.getAbsolutePath).mkString(java.io.File.pathSeparatorChar.toString)
     sys.props("sbt.class.directory") = testcp
@@ -58,9 +58,9 @@ lazy val plugin: Project =
   (project in file("plugin")) settings (
     sharedSettings: _*
   ) settings (
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full),
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
     libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-compiler" % _ % "provided"),
-    libraryDependencies += "org.scalameta" % "scalahost" % "0.1.0-SNAPSHOT" cross CrossVersion.full,
+    libraryDependencies += "org.scalameta" % "scalahost_2.11.8" % "1.6.0",
     assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false, includeDependency = true),
     assemblyJarName in assembly := pluginJarName,
     assemblyMergeStrategy in assembly := {

--- a/build.sbt
+++ b/build.sbt
@@ -8,11 +8,11 @@ lazy val bintraySettings: Seq[Setting[_]] = Seq(
 )
 
 lazy val sharedSettings: Seq[Setting[_]] = Seq(
-  version := "0.1.1",
+  version := "0.1.1-SNAPSHOT",
   scalaVersion := "2.11.8",
   organization := "org.duhemm",
   resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
-  libraryDependencies += "org.scalameta" % "scalameta_2.11" % "1.6.0",
+  libraryDependencies += "org.scalameta" %% "scalameta" % "1.6.0",
   libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect" % _),
   scalaHome := sys.props get scalaHomeProperty map file
 ) ++ bintraySettings

--- a/plugin/src/main/scala/org/duhemm/parsermacro/Validation.scala
+++ b/plugin/src/main/scala/org/duhemm/parsermacro/Validation.scala
@@ -68,7 +68,7 @@ trait Validation extends Signatures { self: Plugin =>
    * This means that their types have to be supertypes of `Seq[scala.meta.Token]`.
    */
   private def parserMacroCompatibleParameters(params: List[Symbol]): Boolean = {
-    val expectedType = typeOf[_root_.scala.meta.syntactic.Tokens]
+    val expectedType = typeOf[_root_.scala.meta.tokens.Tokens]
     params forall (expectedType <:< _.typeSignature)
   }
 

--- a/tests/src/test/scala/boxity/ParserMacroSuite.scala
+++ b/tests/src/test/scala/boxity/ParserMacroSuite.scala
@@ -52,7 +52,6 @@ trait ParserMacroSuite extends FunSuite {
         fail("An error was expected during the compilation, but none was issued.")
       } catch {
         case err @ CompilationFailed(msg) =>
-          println("couldn't compile " + code)
           assert(msg contains expected)
       }
     }

--- a/tests/src/test/scala/boxity/ParserMacroSuite.scala
+++ b/tests/src/test/scala/boxity/ParserMacroSuite.scala
@@ -52,6 +52,7 @@ trait ParserMacroSuite extends FunSuite {
         fail("An error was expected during the compilation, but none was issued.")
       } catch {
         case err @ CompilationFailed(msg) =>
+          println("couldn't compile " + code)
           assert(msg contains expected)
       }
     }

--- a/tests/src/test/scala/macros/DeeplyNestedLightweight.scala
+++ b/tests/src/test/scala/macros/DeeplyNestedLightweight.scala
@@ -8,7 +8,7 @@ object DeeplyNestedParserMacro {
     object Nested {
       object Obj {
         def foo(t: Tokens) = macro {
-          internal.ast.Lit.Int(1)
+          scala.meta.Lit(1)
         }
       }
     }

--- a/tests/src/test/scala/macros/ParserMacros.scala
+++ b/tests/src/test/scala/macros/ParserMacros.scala
@@ -10,35 +10,35 @@ object ParserMacros {
       case x :: xs => 1 + count(xs)
       case Nil => 0
     }
-    internal.ast.Lit.Int(count(tokens.toList))
+    scala.meta.Lit(count(tokens.toList))
   }
 
   def multiParameter(t1: Tokens, t2: Tokens) = macro {
-    internal.ast.Lit.Int(1)
+    scala.meta.Lit(1)
   }
 
   def alwaysReturnOne(t1: Tokens) = macro {
-    internal.ast.Lit.Int(1)
+    scala.meta.Lit(1)
   }
 
   def compatibleParameterType(tokens: Iterable[Token]) = macro {
-    internal.ast.Lit.Int(1)
+    scala.meta.Lit(1)
   }
 
-  def compatibleReturnType(tokens: Tokens): internal.ast.Lit = macro {
-    internal.ast.Lit.Int(1)
+  def compatibleReturnType(tokens: Tokens): Lit = macro {
+    scala.meta.Lit(1)
   }
 
   def hasTypeParameters[T](tokens: Tokens) = macro {
-    internal.ast.Lit.Int(1)
+    scala.meta.Lit(1)
   }
 
   def hasTypeParametersToo[T >: Token](tokens: Seq[T]) = macro {
-    internal.ast.Lit.Int(1)
+    scala.meta.Lit(1)
   }
 
   def alsoHasTypeParameters[T <: Tree](tokens: Tokens) = macro {
-    internal.ast.Lit.Int(1)
+    scala.meta.Lit(1)
   }
 
   // Wrong implementations of parser macros

--- a/tests/src/test/scala/suites/CorrectParserMacros.scala
+++ b/tests/src/test/scala/suites/CorrectParserMacros.scala
@@ -42,7 +42,7 @@ trait CorrectParserMacros extends ParserMacroSuite {
   test("Accept macros defined inside a package object") {
     """import scala.meta._
       |package object incorrect {
-      |  def hello(t: Tokens): Tree = macro { internal.ast.Lit.Int(1) }
+      |  def hello(t: Tokens): Tree = macro { scala.meta.Lit(1) }
       |}""".stripMargin.shouldCompile
   }
 

--- a/tests/src/test/scala/suites/IncorrectParserMacros.scala
+++ b/tests/src/test/scala/suites/IncorrectParserMacros.scala
@@ -12,14 +12,14 @@ trait IncorrectParserMacros extends ParserMacroSuite {
   test("Reject a macro whose owner is not an object") {
     """import scala.meta._
       |class Incorrect {
-      |  def hello(tokens: Tokens) = macro { internal.ast.Lit.Int(1) }
+      |  def hello(tokens: Tokens) = macro { scala.meta.Lit(1) }
       |}""".stripMargin shouldFailWith "macro implementation reference has wrong shape"
   }
 
   test("Reject a macro that has more than one parameter lists") {
     """import scala.meta._
       |object Incorrect {
-      |  def hello(t1: Tokens)(t2: Tokens) = macro { internal.ast.Lit.Int(1) }
+      |  def hello(t1: Tokens)(t2: Tokens) = macro { scala.meta.Lit(1) }
       |}""".stripMargin shouldFailWith "parser macro can have only one parameter list"
   }
 
@@ -28,7 +28,7 @@ trait IncorrectParserMacros extends ParserMacroSuite {
     // as a parser macro, but don't output any error (after all, it may still be a valid whatever-you-want macro)
     """import scala.meta._
       |object Incorrect {
-      |  def hello(x: Map[Int, String]) = macro { internal.ast.Lit.Int(1) }
+      |  def hello(x: Map[Int, String]) = macro { scala.meta.Lit(1) }
       |}""".stripMargin.shouldNotBeConsideredAParserMacro
   }
 
@@ -52,7 +52,7 @@ trait IncorrectParserMacros extends ParserMacroSuite {
   test("Reject parser macro with implicit parameters") {
     """import scala.meta._
       |object Incorrect {
-      |  def hello(implicit tokens: Tokens): Tree = macro { internal.ast.Lit.Int(1) }
+      |  def hello(implicit tokens: Tokens): Tree = macro { scala.meta.Lit(1) }
       |}""".stripMargin shouldFailWith "parser macro cannot have implicit parameters"
   }
 


### PR DESCRIPTION
 upgrading the plugin to compile with the 2.11.8 version of the scala compiler and 1.6.0 version of scalameta